### PR TITLE
Building fail on win32?

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@ on: [push, pull_request]
 jobs:
   test:
     name: test
+    env:
+      RUST_BACKTRACE: full
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install Rust (rustup)
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
-    - run: cargo test --no-default-features --features=${{ matrix.features }}
+    - run: cargo test -vvv --no-default-features --features=${{ matrix.features }}
 
   lint:
     name: lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,13 @@ jobs:
             os: macos-latest
             rust: stable
             features: openssl-vendored
+          - build: windows
+            os: windows-latest
+            rust: stable
+          - build: windows
+            os: windows-latest
+            rust: stable
+            features: openssl-vendored
     steps:
     - if: contains(matrix.os, 'ubuntu')
       run: sudo apt-get install -y yasm


### PR DESCRIPTION
Thank you for your work on `rust-rdkafka` and dependencies. I trying use version with `gssapi-vendored` (cherry-picked only Cargo.toml changes from master), but have problem with compiling it on Windows.

Building fail with:
```
'configure failed: Os { code: 193, kind: Other, message: "%1 is not a valid Win32 application." }'
```

I'm not sure what problem with `build.rs`, so created PR with CI changes which add windows to build matrix.