### PR TITLE
make NLS support configurable via a feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to [Semantic
 Versioning].
 
+## Unreleased
+
+* Disable native language support (NLS) by default, since it complicates linking
+  on some platforms.
+
 ## [0.2.3+1.18.2] - 2020-06-13
 
 * Fix detection of `ar` tool when cross compiling.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,5 @@ duct = "0.13.3"
 
 [features]
 binaries = []
+nls = []
 openssl-vendored = ["openssl-sys/vendored"]

--- a/build.rs
+++ b/build.rs
@@ -49,6 +49,10 @@ fn main() {
             // AES-NI support appears to be broken (perhaps related to static
             // libraries?). See #4.
             "--disable-aesni".into(),
+            #[cfg(feature = "nls")]
+            "--enable-nls".into(),
+            #[cfg(not(feature = "nls"))]
+            "--disable-nls".into(),
             format!("CPPFLAGS={}", cppflags),
             format!("CFLAGS={}", cflags),
         ];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,13 @@
 //!
 //! * **`binaries`** builds the binaries that come with libkrb5 (kinit,
 //!   kdestroy, et al.) and installs them into `DEP_KRB5_SRC_ROOT/bin`.
+//!
+//! * **`nls`** enables native language support (i.e., localization). This
+//!   feature corresponds to the `--enable-nls` configure flag.
+//!
+//!   On some platforms, when this feature is enabled, the application must
+//!   additionally link against libintl.
+//!
 //! * **`openssl-vendored`** enables the `vendored` feature of the `openssl-sys`
 //!   crate.
 //!


### PR DESCRIPTION
NLS is not necessary for Materialize, and breaks the build on FreeBSD. Leave it in as a feature flag for people who need it.