### PR TITLE
Unconditionally provide host and build args (fixes build for arm64-apple-darwin)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -42,7 +42,7 @@ fn main() {
             cppflags += &format!(" -I{}", Path::new(&openssl_root).join("include").display());
         }
 
-        let mut configure_args = vec![
+        let configure_args = vec![
             format!("--prefix={}", install_dir.display()),
             "--enable-static".into(),
             "--disable-shared".into(),
@@ -55,12 +55,11 @@ fn main() {
             "--disable-nls".into(),
             format!("CPPFLAGS={}", cppflags),
             format!("CFLAGS={}", cflags),
+            // The system on which the library is built.
+            format!("--build={}", host),
+            // The system on which the library is run.
+            format!("--host={}", target),
         ];
-
-        // If we're cross-compiling, let configure know.
-        if host != target {
-            configure_args.push(format!("--host={}", target));
-        }
 
         let configure_path = Path::new("krb5").join("src").join("configure");
         cmd(configure_path, &configure_args)


### PR DESCRIPTION
Follow up to https://github.com/MaterializeInc/rust-krb5-src/pull/15, this time with correct arguments for `build` and `host` according to https://www.gnu.org/software/automake/manual/html_node/Cross_002dCompilation.html.